### PR TITLE
Add GHC 9.2, 9.4, 9.6 to CI matrix

### DIFF
--- a/.github/workflows/cabal.yaml
+++ b/.github/workflows/cabal.yaml
@@ -12,6 +12,9 @@ jobs:
       fail-fast: false
       matrix:
         ghc:
+          - '9.2'
+          - '9.4'
+          - '9.6'
           - '9.8'
           - '9.10'
         os: [ubuntu-latest, macOS-latest, windows-latest]


### PR DESCRIPTION
## Summary
- Adds GHC 9.2, 9.4, and 9.6 to the cabal CI workflow matrix
- crypton depends on ram and needs to support these GHC versions
- ram's code already has proper CPP guards for these GHC versions

## Test plan
- [ ] CI passes on GHC 9.2, 9.4, 9.6 across all OS targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)