### PR TITLE
Add map function for byte arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.22.0
++ Added `map :: (ByteArrayAccess ba, ByteArray ba) => (Word8 -> Word8) -> ba -> ba`
+  to `Data.ByteArray.Methods` (re-exported via `Data.ByteArray`).
+  Applies a function to each byte of a byte array. (closes #5)
+
 ## 0.21.1
 + Reverted 0.21.0 changes: restored custom Base16/Base32/Base64 encode/decode,
   the GHC.Prim-based `Bytes` implementation, and `readWord8OffAddr#`-based FNV

--- a/Data/ByteArray/Methods.hs
+++ b/Data/ByteArray/Methods.hs
@@ -39,6 +39,7 @@ module Data.ByteArray.Methods
     , all
     , append
     , concat
+    , map
     ) where
 
 import           Data.ByteArray.Types
@@ -49,7 +50,7 @@ import           Data.Monoid
 import           Foreign.Storable
 import           Foreign.Ptr
 
-import           Prelude hiding (length, take, drop, span, reverse, concat, replicate, splitAt, null, pred, last, any, all)
+import           Prelude hiding (length, take, drop, span, reverse, concat, replicate, splitAt, null, pred, last, any, all, map)
 import qualified Prelude
 
 
@@ -200,7 +201,7 @@ reverse bs = unsafeCreate n $ \d -> withByteArray bs $ \s -> memReverse d s n
 concat :: (ByteArrayAccess bin, ByteArray bout) => [bin] -> bout
 concat l = unsafeCreate retLen (loopCopy l)
   where
-    retLen = sum $ map length l
+    retLen = sum $ Prelude.map length l
 
     loopCopy []     _   = return ()
     loopCopy (x:xs) dst = do
@@ -295,6 +296,19 @@ any f b
 -- | Check if all elements of a byte array satisfy a predicate
 all :: (ByteArrayAccess ba) => (Word8 -> Bool) -> ba -> Bool
 all f b = not (any (not . f) b)
+
+-- | Map a function over each byte of a bytearray
+map :: (ByteArrayAccess ba, ByteArray ba) => (Word8 -> Word8) -> ba -> ba
+map f ba = copyAndFreeze ba $ loop 0
+  where
+    len = length ba
+    loop i ptr
+        | i == len  = return ()
+        | otherwise = do
+            let ptr' = ptr `plusPtr` i
+            x <- peek ptr'
+            poke ptr' $ f x
+            loop (i + 1) ptr
 
 -- | Convert a bytearray to another type of bytearray
 convert :: (ByteArrayAccess bin, ByteArray bout) => bin -> bout

--- a/ram.cabal
+++ b/ram.cabal
@@ -1,6 +1,6 @@
 cabal-version:   3.0
 name:            ram
-version:         0.21.1
+version:         0.22.0
 synopsis:        memory and related abstraction stuff
 description:
   This is a fork of memory. It's open to accept changes from anyone,

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -248,4 +248,8 @@ main = defaultMain $ testGroup "memory"
         , testProperty "span (const False)" $ \(Words8 l) ->
             let b = witnessID (B.pack l)
              in B.span (const False) b == (B.empty, b)
+        , testProperty "map f == pack . Prelude.map f . unpack" $ \(Words8 l) (Positive w) ->
+            let b = witnessID (B.pack l)
+                f x = x + fromIntegral w :: Word8
+             in B.map f b == (witnessID . B.pack . Prelude.map f $ l)
         ]


### PR DESCRIPTION
## Summary
- Adds `map :: (ByteArrayAccess ba, ByteArray ba) => (Word8 -> Word8) -> ba -> ba` to `Data.ByteArray.Methods` (re-exported via `Data.ByteArray`), as requested in #5
- Uses `copyAndFreeze` to copy the array then mutate each byte in-place
- Bumps version to 0.22.0
- Adds QuickCheck property test verifying `B.map f == B.pack . Prelude.map f . B.unpack`

Closes #5

## Test plan
- [x] `cabal build` passes with no new warnings
- [x] `cabal test` — all 278 tests pass (including new `map` test for both `Bytes` and `ScrubbedBytes` backends)
- [x] `nix-build nix/ci.nix` succeeds
- [x] New test verified to fail on master (compile error: `B.map` not in scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)